### PR TITLE
Add Korean and English translation support to web portal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Backend configuration
+LAN_IFACE=eno1
+BROADCAST=192.168.219.255
+WOL_METHOD=python
+LOG_PATH=logs/wol-web.jsonl
+LOG_RETENTION_DAYS=7
+LOG_MAX_LIMIT=500
+HOST=127.0.0.1
+PORT=8000
+
+# Optional single target override
+PC_LABEL=
+PC_IP=
+PC_MAC=
+
+# Frontend configuration
+NEXT_PUBLIC_API_BASE=http://localhost:8000
+NEXT_PUBLIC_GRAFANA_URL=https://mon-core.tail85b0de.ts.net:445/
+NEXT_PUBLIC_PROM_URL=https://mon-core.tail85b0de.ts.net/prometheus/targets
+NEXT_PUBLIC_KUMA_URL=https://mon-core.tail85b0de.ts.net:444/status/portal
+NEXT_PUBLIC_NETDATA_URL=https://mon-core.tail85b0de.ts.net/netdata/

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 .venv/
 .env
 .env.*
+!.env.example
 # Editors
 .vscode/
 .idea/

--- a/docs/portal-customization-overview.md
+++ b/docs/portal-customization-overview.md
@@ -1,0 +1,19 @@
+# Portal Customization Architecture
+
+## Overview
+This document explains how the portal supports per-user customization for language, theme, and monitoring routes, alongside the settings page that exposes these options.
+
+## Global Providers
+`web/app/providers.tsx` wraps the entire Next.js app in the language and portal configuration contexts so every page can read or mutate user preferences without prop drilling.【F:web/app/providers.tsx†L1-L14】
+
+## Localization System
+The `LanguageProvider` owns the current locale, loads the English and Korean JSON dictionaries, and exposes a `t()` helper for nested key lookups with interpolation and an English fallback.【F:web/app/_i18n/LanguageProvider.tsx†L1-L143】 Translation strings live in `web/app/_i18n/translations/*.json`; they group copy by feature (e.g., `monitoring`, `wol`, `settings`) so UI components can request phrases like `t('settings.appearance.title')`.【F:web/app/_i18n/translations/en.json†L1-L36】 The provider persists the selection to `localStorage` and syncs the document language attribute for accessibility.【F:web/app/_i18n/LanguageProvider.tsx†L72-L112】
+
+## Portal Route Configuration
+`PortalConfigProvider` resolves monitoring URLs by merging build-time defaults, environment-driven overrides, and any user-specified replacements stored in `localStorage`.【F:web/app/_settings/PortalConfigProvider.tsx†L1-L82】 Environment defaults are declared in `web/app/(portal)/monitoring/constants.ts` with matching `NEXT_PUBLIC_*` keys so the frontend mirrors `.env.example` values.【F:web/app/(portal)/monitoring/constants.ts†L1-L41】【F:.env.example†L1-L21】
+
+## Settings Page
+The `/settings` route consumes both providers to render radio groups for theme and language, editable monitoring URLs with reset support, and a quick Wake-on-LAN target form that reuses the existing API client for submissions.【F:web/app/settings/page.tsx†L1-L260】 Hint text surfaces the associated environment key for each monitoring field so operators know which variables feed the defaults.【F:web/app/settings/page.tsx†L186-L206】 Successful submissions reset the form and show localized status messages, while errors bubble request details where available.【F:web/app/settings/page.tsx†L209-L257】
+
+## Environment Variables
+`.env.example` ships with representative backend and frontend defaults, ensuring new deployments understand which variables control API hosts and monitoring dashboards.【F:.env.example†L1-L21】

--- a/web/app/(management)/wol/_components/ConfirmDeleteModal.tsx
+++ b/web/app/(management)/wol/_components/ConfirmDeleteModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { Target } from '../_lib/types';
+import { useLanguage } from '../../../_i18n/LanguageProvider';
 
 type ConfirmDeleteModalProps = {
   target: Target | null;
@@ -9,6 +10,8 @@ type ConfirmDeleteModalProps = {
 };
 
 export function ConfirmDeleteModal({ target, onConfirm, onCancel }: ConfirmDeleteModalProps) {
+  const { t } = useLanguage();
+
   if (!target) {
     return null;
   }
@@ -26,14 +29,14 @@ export function ConfirmDeleteModal({ target, onConfirm, onCancel }: ConfirmDelet
       }}
     >
       <div className="dialog-shell">
-        <h2 id="confirm-modal-title">Confirm Delete</h2>
-        <p>Delete target {target.name}?</p>
+        <h2 id="confirm-modal-title">{t('wol.confirmDelete.title')}</h2>
+        <p>{t('wol.confirmDelete.message', { name: target.name })}</p>
         <div className="modal-actions">
           <button type="button" className="btn danger" onClick={onConfirm}>
-            Delete
+            {t('wol.confirmDelete.delete')}
           </button>
           <button type="button" className="btn ghost" onClick={onCancel}>
-            Cancel
+            {t('wol.confirmDelete.cancel')}
           </button>
         </div>
       </div>

--- a/web/app/(management)/wol/_components/LogsCard.tsx
+++ b/web/app/(management)/wol/_components/LogsCard.tsx
@@ -1,14 +1,10 @@
 'use client';
 
-import { ACTION_LABELS } from '../_lib/constants';
+import { useMemo } from 'react';
+
 import { formatRelative, formatTime } from '../_lib/format';
 import type { LogEntry } from '../_lib/types';
-
-const STATUS_LABELS: Record<LogEntry['status'], string> = {
-  pending: 'In Progress',
-  success: 'Success',
-  error: 'Failed'
-};
+import { useLanguage } from '../../../_i18n/LanguageProvider';
 
 type LogsCardProps = {
   logs: LogEntry[];
@@ -16,39 +12,55 @@ type LogsCardProps = {
 };
 
 export function LogsCard({ logs, onClear }: LogsCardProps) {
+  const { t } = useLanguage();
+  const statusLabels = useMemo<Record<LogEntry['status'], string>>(
+    () => ({
+      pending: t('wol.logs.status.pending'),
+      success: t('wol.logs.status.success'),
+      error: t('wol.logs.status.error')
+    }),
+    [t]
+  );
+
+  const title = t('wol.logs.title');
+  const subtitle = t('wol.logs.subtitle');
+  const clearLabel = t('wol.logs.clear');
+  const emptyState = t('wol.logs.empty');
+  const targetLabel = t('wol.logs.targetLabel');
+
   return (
     <section className="card logs-card">
       <div className="card-header">
         <div>
-          <h2>Action History</h2>
-          <p className="card-subtitle">Only commands you trigger from this page are listed.</p>
+          <h2>{title}</h2>
+          <p className="card-subtitle">{subtitle}</p>
         </div>
         <div className="header-actions compact">
           <button className="btn ghost" id="logs-clear" onClick={onClear} disabled={logs.length === 0}>
-            Clear
+            {clearLabel}
           </button>
         </div>
       </div>
       <div className="logs-list" id="logs-list">
         {logs.length === 0 ? (
-          <div className="empty-state">No actions yet. Use the controls above to send a command.</div>
+          <div className="empty-state">{emptyState}</div>
         ) : (
           logs.map((entry) => {
             const actionClass = `action-log-item action-log-item--${entry.action}`;
             const statusClass = `action-log-status action-log-status--${entry.status}`;
-            const actionLabel = ACTION_LABELS[entry.action] ?? entry.action;
+            const actionLabel = t(`wol.actions.labels.${entry.action}`);
 
             return (
               <article className={actionClass} key={entry.id}>
                 <header className="action-log-header">
                   <span className="action-log-action">{actionLabel}</span>
-                  <span className={statusClass}>{STATUS_LABELS[entry.status]}</span>
+                  <span className={statusClass}>{statusLabels[entry.status]}</span>
                   <span className="action-log-time" title={new Date(entry.timestamp).toLocaleString()}>
-                    {formatTime(entry.timestamp)} · {formatRelative(entry.timestamp)}
+                    {formatTime(entry.timestamp)} · {formatRelative(entry.timestamp, t)}
                   </span>
                 </header>
                 <div className="action-log-body">
-                  <span className="action-log-target" aria-label="Target">
+                  <span className="action-log-target" aria-label={targetLabel}>
                     {entry.target}
                   </span>
                   <p className="action-log-message">{entry.message}</p>

--- a/web/app/(management)/wol/_components/PortalDialog.tsx
+++ b/web/app/(management)/wol/_components/PortalDialog.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useLanguage } from '../../../_i18n/LanguageProvider';
+
 type PortalDialogProps = {
   open: boolean;
   src: string;
@@ -7,9 +9,15 @@ type PortalDialogProps = {
 };
 
 export function PortalDialog({ open, src, onClose }: PortalDialogProps) {
+  const { t } = useLanguage();
+
   if (!open) {
     return null;
   }
+
+  const title = t('monitoring.dialogTitle');
+  const closeLabel = t('monitoring.dialogClose');
+  const iframeTitle = t('monitoring.dialogFrameTitle');
 
   return (
     <div
@@ -25,12 +33,12 @@ export function PortalDialog({ open, src, onClose }: PortalDialogProps) {
     >
       <div className="portal-dialog-shell">
         <header className="portal-dialog__header">
-          <h2 id="portal-dialog-title">Monitoring Portal</h2>
+          <h2 id="portal-dialog-title">{title}</h2>
           <button type="button" className="portal-dialog__close" onClick={onClose}>
-            Close
+            {closeLabel}
           </button>
         </header>
-        <iframe className="portal-dialog__iframe" src={src} title="Monitoring portal" loading="lazy" />
+        <iframe className="portal-dialog__iframe" src={src} title={iframeTitle} loading="lazy" />
       </div>
     </div>
   );

--- a/web/app/(management)/wol/_components/TargetModal.tsx
+++ b/web/app/(management)/wol/_components/TargetModal.tsx
@@ -3,6 +3,7 @@
 import type { FormEventHandler } from 'react';
 
 import type { TargetFormState } from '../_lib/types';
+import { useLanguage } from '../../../_i18n/LanguageProvider';
 
 type TargetModalProps = {
   open: boolean;
@@ -15,9 +16,13 @@ type TargetModalProps = {
 };
 
 export function TargetModal({ open, mode, form, error, onChange, onClose, onSubmit }: TargetModalProps) {
+  const { t } = useLanguage();
+
   if (!open) {
     return null;
   }
+
+  const title = mode === 'edit' ? t('wol.targetModal.title.edit') : t('wol.targetModal.title.create');
 
   return (
     <div
@@ -33,9 +38,9 @@ export function TargetModal({ open, mode, form, error, onChange, onClose, onSubm
     >
       <div className="dialog-shell">
         <form id="target-form" onSubmit={onSubmit}>
-          <h2 id="target-modal-title">{mode === 'edit' ? 'Edit Target' : 'Add Target'}</h2>
+          <h2 id="target-modal-title">{title}</h2>
           <label className="field">
-            <span>Name</span>
+            <span>{t('wol.targetModal.fields.name')}</span>
             <input
               name="name"
               value={form.name}
@@ -46,42 +51,42 @@ export function TargetModal({ open, mode, form, error, onChange, onClose, onSubm
               pattern="[a-z0-9-]+"
               autoComplete="off"
             />
-            <small>Use lowercase letters, numbers, and hyphen only (e.g., mainpc).</small>
+            <small>{t('wol.targetModal.fields.nameHint')}</small>
           </label>
           <label className="field">
-            <span>IP address</span>
+            <span>{t('wol.targetModal.fields.ip')}</span>
             <input
               name="ip"
               value={form.ip}
               onChange={(event) => onChange({ ...form, ip: event.target.value })}
               required
-              placeholder="192.168.0.10"
+              placeholder={t('wol.targetModal.fields.ipPlaceholder')}
               autoComplete="off"
             />
           </label>
           <details className="field advanced" open={Boolean(form.mac)}>
-            <summary>Advanced (MAC address)</summary>
+            <summary>{t('wol.targetModal.fields.advancedSummary')}</summary>
             <label>
-              <span>MAC address (optional)</span>
+              <span>{t('wol.targetModal.fields.mac')}</span>
               <input
                 name="mac"
                 value={form.mac}
                 onChange={(event) => onChange({ ...form, mac: event.target.value })}
-                placeholder="AA:BB:CC:DD:EE:FF"
+                placeholder={t('wol.targetModal.fields.macPlaceholder')}
                 autoComplete="off"
               />
             </label>
-            <small>If omitted, MAC is learned automatically when the device is online.</small>
+            <small>{t('wol.targetModal.fields.macHint')}</small>
           </details>
           <p className="form-error" id="target-form-error">
             {error}
           </p>
           <div className="modal-actions">
             <button type="submit" className="btn primary" id="target-save">
-              Save
+              {t('wol.targetModal.actions.save')}
             </button>
             <button type="button" className="btn ghost" onClick={onClose}>
-              Cancel
+              {t('wol.targetModal.actions.cancel')}
             </button>
           </div>
         </form>

--- a/web/app/(management)/wol/_components/TargetsCard.tsx
+++ b/web/app/(management)/wol/_components/TargetsCard.tsx
@@ -2,6 +2,7 @@
 
 import type { PowerAction, Target } from '../_lib/types';
 import { formatRelative } from '../_lib/format';
+import { useLanguage } from '../../../_i18n/LanguageProvider';
 
 type TargetsCardProps = {
   targets: Target[];
@@ -20,35 +21,66 @@ export function TargetsCard({
   onEdit,
   onDelete
 }: TargetsCardProps) {
+  const { t } = useLanguage();
+  const title = t('wol.targets.title');
+  const subtitle = t('wol.targets.subtitle');
+  const summary = t('wol.targets.summary', { total: targets.length, showing: filteredTargets.length });
+  const columnLabels = {
+    name: t('wol.targets.columns.name'),
+    ip: t('wol.targets.columns.ip'),
+    mac: t('wol.targets.columns.mac'),
+    status: t('wol.targets.columns.status'),
+    recent: t('wol.targets.columns.recent'),
+    actions: t('wol.targets.columns.actions')
+  };
+  const statusLabels = {
+    online: t('wol.targets.status.online'),
+    offline: t('wol.targets.status.offline'),
+    unknown: t('wol.targets.status.unknown')
+  };
+  const macNotSet = t('wol.targets.macNotSet');
+  const macBadge = t('wol.targets.macMissingBadge');
+  const wakeDisabledLabel = t('wol.targets.wakeDisabled');
+  const wakeTitle = t('wol.targets.wakeTitle');
+  const actionLabels = {
+    wake: t('wol.targets.actions.wake'),
+    shutdown: t('wol.targets.actions.shutdown'),
+    reboot: t('wol.targets.actions.reboot'),
+    edit: t('wol.targets.actions.edit'),
+    delete: t('wol.targets.actions.delete')
+  };
+  const emptyState = t('wol.targets.empty');
+
   return (
     <section className="card targets-card">
       <div className="card-header">
         <div>
-          <h2>Targets</h2>
-          <p className="card-subtitle">Wake, shut down, or reboot devices registered in your Tailnet.</p>
+          <h2>{title}</h2>
+          <p className="card-subtitle">{subtitle}</p>
         </div>
         <span className="status-indicator" id="status-indicator">
-          {`Total ${targets.length} / Showing ${filteredTargets.length}`}
+          {summary}
         </span>
       </div>
       <div className="table-wrapper">
         <table className="targets-table">
           <thead>
             <tr>
-              <th>Name</th>
-              <th>IP</th>
-              <th>MAC</th>
-              <th>Status</th>
-              <th>Recent</th>
-              <th className="actions-col">Actions</th>
+              <th>{columnLabels.name}</th>
+              <th>{columnLabels.ip}</th>
+              <th>{columnLabels.mac}</th>
+              <th>{columnLabels.status}</th>
+              <th>{columnLabels.recent}</th>
+              <th className="actions-col">{columnLabels.actions}</th>
             </tr>
           </thead>
           <tbody>
             {filteredTargets.map((target) => {
               const status = target.online === true ? 'online' : target.online === false ? 'offline' : 'unknown';
-              const statusLabel = status === 'online' ? 'Online' : status === 'offline' ? 'Offline' : 'Unknown';
+              const statusLabel =
+                status === 'online' ? statusLabels.online : status === 'offline' ? statusLabels.offline : statusLabels.unknown;
               const badgeClass = status === 'online' ? 'badge online' : status === 'offline' ? 'badge offline' : 'badge';
-              const mac = target.mac || 'Not set';
+              const mac = target.mac || macNotSet;
               const macClass = target.mac ? '' : 'mac-missing';
               const recent = target.last_wake_at || target.last_status_at || target.updated_at || target.created_at;
               const wakeDisabled = !target.has_mac;
@@ -58,30 +90,30 @@ export function TargetsCard({
 
               return (
                 <tr key={target.name}>
-                  <td data-label="Name">
+                  <td data-label={columnLabels.name}>
                     <div className="target-name">{target.name}</div>
-                    {!target.has_mac ? <span className="badge warn">MAC not set</span> : null}
+                    {!target.has_mac ? <span className="badge warn">{macBadge}</span> : null}
                   </td>
-                  <td data-label="IP">{target.ip ?? '-'}</td>
-                  <td data-label="MAC" className={macClass}>
+                  <td data-label={columnLabels.ip}>{target.ip ?? '-'}</td>
+                  <td data-label={columnLabels.mac} className={macClass}>
                     {mac}
                   </td>
-                  <td data-label="Status">
+                  <td data-label={columnLabels.status}>
                     <span className={badgeClass}>{statusLabel}</span>
                   </td>
-                  <td data-label="Recent">{formatRelative(recent)}</td>
-                  <td className="actions" data-label="Actions">
+                  <td data-label={columnLabels.recent}>{formatRelative(recent, t)}</td>
+                  <td className="actions" data-label={columnLabels.actions}>
                     <div className="button-group">
                       <button
                         className="btn small"
                         data-action="wake"
                         data-name={target.name}
                         disabled={wakeDisabled}
-                        title={wakeDisabled ? 'MAC not set - Wake disabled' : 'Wake on LAN'}
+                        title={wakeDisabled ? wakeDisabledLabel : wakeTitle}
                         data-loading={actionLoadingKey === wakeKey ? 'true' : undefined}
                         onClick={() => onAction(target, 'wake')}
                       >
-                        Wake
+                        {actionLabels.wake}
                       </button>
                       <button
                         className="btn small secondary"
@@ -90,7 +122,7 @@ export function TargetsCard({
                         data-loading={actionLoadingKey === shutdownKey ? 'true' : undefined}
                         onClick={() => onAction(target, 'shutdown')}
                       >
-                        Shutdown
+                        {actionLabels.shutdown}
                       </button>
                       <button
                         className="btn small secondary"
@@ -99,15 +131,15 @@ export function TargetsCard({
                         data-loading={actionLoadingKey === rebootKey ? 'true' : undefined}
                         onClick={() => onAction(target, 'reboot')}
                       >
-                        Reboot
+                        {actionLabels.reboot}
                       </button>
                     </div>
                     <div className="button-group secondary">
                       <button className="btn small ghost" onClick={() => onEdit(target)}>
-                        Edit
+                        {actionLabels.edit}
                       </button>
                       <button className="btn small ghost" onClick={() => onDelete(target)}>
-                        Delete
+                        {actionLabels.delete}
                       </button>
                     </div>
                   </td>
@@ -116,9 +148,7 @@ export function TargetsCard({
             })}
           </tbody>
         </table>
-        {filteredTargets.length === 0 ? (
-          <div className="empty-state">No targets yet. Use the “+ Add Target” button to get started.</div>
-        ) : null}
+        {filteredTargets.length === 0 ? <div className="empty-state">{emptyState}</div> : null}
       </div>
     </section>
   );

--- a/web/app/(management)/wol/_components/WolHeader.tsx
+++ b/web/app/(management)/wol/_components/WolHeader.tsx
@@ -3,8 +3,6 @@
 import Link from 'next/link';
 import type { ChangeEventHandler } from 'react';
 
-import { LanguageToggle } from '../../../_components/LanguageToggle';
-import { MoonIcon, SunIcon } from '../../../_components/ThemeIcons';
 import { useLanguage } from '../../../_i18n/LanguageProvider';
 
 type WolHeaderProps = {
@@ -12,32 +10,18 @@ type WolHeaderProps = {
   onFilterChange: ChangeEventHandler<HTMLInputElement>;
   onRefreshStatus: () => void;
   onOpenPortal: () => void;
-  onToggleTheme: () => void;
   onAddTarget: () => void;
-  theme: 'light' | 'dark';
-  themeReady: boolean;
 };
 
-export function WolHeader({
-  filter,
-  onFilterChange,
-  onRefreshStatus,
-  onOpenPortal,
-  onToggleTheme,
-  onAddTarget,
-  theme,
-  themeReady
-}: WolHeaderProps) {
+export function WolHeader({ filter, onFilterChange, onRefreshStatus, onOpenPortal, onAddTarget }: WolHeaderProps) {
   const { t } = useLanguage();
-  const themeLabel = theme === 'light' ? t('common.theme.dark') : t('common.theme.light');
-  const themeAriaLabel = theme === 'light' ? t('common.theme.switchToDark') : t('common.theme.switchToLight');
-  const ThemeIcon = theme === 'light' ? MoonIcon : SunIcon;
   const title = t('wol.header.title');
   const subtitle = t('wol.header.subtitle');
   const searchPlaceholder = t('wol.header.searchPlaceholder');
   const refreshLabel = t('wol.header.refresh');
   const portalLabel = t('wol.header.portal');
   const addTargetLabel = t('wol.header.addTarget');
+  const settingsLabel = t('settings.linkLabel');
 
   return (
     <header className="page-header">
@@ -60,21 +44,9 @@ export function WolHeader({
         <button className="btn secondary" id="open-portal" type="button" aria-haspopup="dialog" onClick={onOpenPortal}>
           {portalLabel}
         </button>
-        <LanguageToggle />
-        <button
-          id="theme-toggle"
-          type="button"
-          className="theme-toggle"
-          onClick={onToggleTheme}
-          aria-label={themeAriaLabel}
-        >
-          {themeReady ? (
-            <ThemeIcon className="theme-toggle__icon" focusable="false" />
-          ) : (
-            <SunIcon className="theme-toggle__icon" focusable="false" />
-          )}
-          <span id="theme-label">{themeLabel}</span>
-        </button>
+        <Link className="btn ghost settings-link" href="/settings">
+          {settingsLabel}
+        </Link>
         <button className="btn primary" id="add-target" onClick={onAddTarget}>
           {addTargetLabel}
         </button>

--- a/web/app/(management)/wol/_components/WolHeader.tsx
+++ b/web/app/(management)/wol/_components/WolHeader.tsx
@@ -2,7 +2,10 @@
 
 import Link from 'next/link';
 import type { ChangeEventHandler } from 'react';
+
+import { LanguageToggle } from '../../../_components/LanguageToggle';
 import { MoonIcon, SunIcon } from '../../../_components/ThemeIcons';
+import { useLanguage } from '../../../_i18n/LanguageProvider';
 
 type WolHeaderProps = {
   filter: string;
@@ -25,31 +28,39 @@ export function WolHeader({
   theme,
   themeReady
 }: WolHeaderProps) {
-  const themeLabel = theme === 'light' ? 'Dark' : 'Light';
-  const themeAriaLabel = theme === 'light' ? 'Switch to dark theme' : 'Switch to light theme';
+  const { t } = useLanguage();
+  const themeLabel = theme === 'light' ? t('common.theme.dark') : t('common.theme.light');
+  const themeAriaLabel = theme === 'light' ? t('common.theme.switchToDark') : t('common.theme.switchToLight');
   const ThemeIcon = theme === 'light' ? MoonIcon : SunIcon;
+  const title = t('wol.header.title');
+  const subtitle = t('wol.header.subtitle');
+  const searchPlaceholder = t('wol.header.searchPlaceholder');
+  const refreshLabel = t('wol.header.refresh');
+  const portalLabel = t('wol.header.portal');
+  const addTargetLabel = t('wol.header.addTarget');
 
   return (
     <header className="page-header">
       <div className="title-block">
-        <h1>WOL-Web</h1>
-        <p>Control Wake-on-LAN and power actions for your Tailnet devices.</p>
+        <h1>{title}</h1>
+        <p>{subtitle}</p>
       </div>
       <div className="header-actions">
         <input
           id="target-filter"
           type="search"
-          placeholder="Search name or IP"
+          placeholder={searchPlaceholder}
           value={filter}
           onChange={onFilterChange}
           autoComplete="off"
         />
         <button className="btn ghost" id="status-refresh" onClick={onRefreshStatus}>
-          Refresh Status
+          {refreshLabel}
         </button>
         <button className="btn secondary" id="open-portal" type="button" aria-haspopup="dialog" onClick={onOpenPortal}>
-          Monitoring Window
+          {portalLabel}
         </button>
+        <LanguageToggle />
         <button
           id="theme-toggle"
           type="button"
@@ -65,7 +76,7 @@ export function WolHeader({
           <span id="theme-label">{themeLabel}</span>
         </button>
         <button className="btn primary" id="add-target" onClick={onAddTarget}>
-          + Add Target
+          {addTargetLabel}
         </button>
       </div>
     </header>
@@ -73,14 +84,16 @@ export function WolHeader({
 }
 
 export function PortalBanner() {
+  const { t } = useLanguage();
+
   return (
     <section className="portal-inline-banner" aria-labelledby="portal-inline-banner-title">
       <div className="portal-inline-banner__text">
-        <h2 id="portal-inline-banner-title">Monitoring Portal</h2>
-        <p>Open the monitoring portal anytime for dashboards and telemetry.</p>
+        <h2 id="portal-inline-banner-title">{t('wol.banner.title')}</h2>
+        <p>{t('wol.banner.description')}</p>
       </div>
       <Link className="btn secondary portal-inline-banner__link" href="/">
-        Open Portal
+        {t('wol.banner.open')}
       </Link>
     </section>
   );

--- a/web/app/(management)/wol/_lib/constants.ts
+++ b/web/app/(management)/wol/_lib/constants.ts
@@ -1,27 +1,9 @@
 import type { PowerAction } from './types';
 
-export const ACTION_CONFIG: Record<PowerAction, { path: string; success: (name: string) => string; failure: string }> = {
-  wake: {
-    path: 'api/wake',
-    success: (name) => `Sent Wake command to ${name}.`,
-    failure: 'Failed to send Wake command.'
-  },
-  shutdown: {
-    path: 'api/shutdown',
-    success: (name) => `Sent Shutdown command to ${name}.`,
-    failure: 'Failed to send Shutdown command.'
-  },
-  reboot: {
-    path: 'api/reboot',
-    success: (name) => `Sent Reboot command to ${name}.`,
-    failure: 'Failed to send Reboot command.'
-  }
-};
-
-export const ACTION_LABELS: Record<PowerAction, string> = {
-  wake: 'Wake',
-  shutdown: 'Shutdown',
-  reboot: 'Reboot'
+export const ACTION_ENDPOINTS: Record<PowerAction, string> = {
+  wake: 'api/wake',
+  shutdown: 'api/shutdown',
+  reboot: 'api/reboot'
 };
 
 export const PORTAL_URL = '/';

--- a/web/app/(management)/wol/_lib/format.ts
+++ b/web/app/(management)/wol/_lib/format.ts
@@ -1,4 +1,26 @@
-export function formatRelative(ts?: string | null): string {
+import type { TranslateFn } from '../../../_i18n/LanguageProvider';
+
+function translateRelative(
+  key: 'justNow' | 'minutesAgo' | 'hoursAgo',
+  t?: TranslateFn,
+  count?: number
+): string {
+  if (t) {
+    return t(`format.relative.${key}`, count !== undefined ? { count } : undefined);
+  }
+  switch (key) {
+    case 'justNow':
+      return 'just now';
+    case 'minutesAgo':
+      return `${count ?? 0} min ago`;
+    case 'hoursAgo':
+      return `${count ?? 0} hr ago`;
+    default:
+      return '';
+  }
+}
+
+export function formatRelative(ts?: string | null, t?: TranslateFn): string {
   if (!ts) return '-';
   const date = new Date(ts);
   if (Number.isNaN(date.getTime())) {
@@ -9,9 +31,9 @@ export function formatRelative(ts?: string | null): string {
   const minute = 60_000;
   const hour = 60 * minute;
   const day = 24 * hour;
-  if (abs < minute) return 'just now';
-  if (abs < hour) return `${Math.round(abs / minute)} min ago`;
-  if (abs < day) return `${Math.round(abs / hour)} hr ago`;
+  if (abs < minute) return translateRelative('justNow', t);
+  if (abs < hour) return translateRelative('minutesAgo', t, Math.round(abs / minute));
+  if (abs < day) return translateRelative('hoursAgo', t, Math.round(abs / hour));
   return date.toLocaleString();
 }
 

--- a/web/app/(management)/wol/page.tsx
+++ b/web/app/(management)/wol/page.tsx
@@ -34,7 +34,7 @@ const ACTION_LOG_LIMIT = 120;
 export default function WolPage() {
   useBodyClass('wol-body');
 
-  const { theme, toggleTheme, ready } = useTheme();
+  useTheme();
   const { t } = useLanguage();
   const { toasts, showToast } = useToastQueue();
 
@@ -315,10 +315,7 @@ export default function WolPage() {
         onFilterChange={(event) => setFilter(event.target.value)}
         onRefreshStatus={() => refreshStatuses({ log: true })}
         onOpenPortal={() => setPortalOpen(true)}
-        onToggleTheme={toggleTheme}
         onAddTarget={openCreateModal}
-        theme={theme}
-        themeReady={ready}
       />
 
       <main className="layout">

--- a/web/app/(portal)/monitoring/components/PortalFrame.tsx
+++ b/web/app/(portal)/monitoring/components/PortalFrame.tsx
@@ -1,13 +1,23 @@
 'use client';
 
+import { useLanguage } from '../../../_i18n/LanguageProvider';
+
 type PortalFrameProps = {
   src: string;
 };
 
 export function PortalFrame({ src }: PortalFrameProps) {
+  const { t } = useLanguage();
+
   return (
     <main className="portal-main">
-      <iframe id="portal-panel" className="portal-panel" src={src} title="Monitoring iframe" loading="lazy" />
+      <iframe
+        id="portal-panel"
+        className="portal-panel"
+        src={src}
+        title={t('monitoring.frameTitle')}
+        loading="lazy"
+      />
     </main>
   );
 }

--- a/web/app/(portal)/monitoring/components/PortalHeader.tsx
+++ b/web/app/(portal)/monitoring/components/PortalHeader.tsx
@@ -1,16 +1,18 @@
 'use client';
 
 import Link from 'next/link';
-import { Fragment, useEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
-  PORTAL_LINKS,
   PORTAL_VIEWS,
+  getPortalLinks,
   formatPortalViewLabel,
   type PortalLink,
   type PortalView
 } from '../constants';
 import { MoonIcon, SunIcon } from '../../../_components/ThemeIcons';
+import { LanguageToggle } from '../../../_components/LanguageToggle';
+import { useLanguage } from '../../../_i18n/LanguageProvider';
 
 type PortalHeaderProps = {
   activeView: PortalView;
@@ -59,8 +61,10 @@ function renderMenuItem(link: PortalLink, onNavigate?: () => void) {
 }
 
 export function PortalHeader({ activeView, onSelectView, onRefresh, onToggleTheme, theme, themeReady }: PortalHeaderProps) {
+  const { t } = useLanguage();
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const portalLinks = useMemo(() => getPortalLinks(t), [t]);
 
   useEffect(() => {
     if (!menuOpen) {
@@ -81,15 +85,20 @@ export function PortalHeader({ activeView, onSelectView, onRefresh, onToggleThem
     return () => document.removeEventListener('click', handleClick);
   }, [menuOpen]);
 
-  const themeLabel = theme === 'light' ? 'Dark' : 'Light';
-  const themeAriaLabel = theme === 'light' ? 'Switch to dark theme' : 'Switch to light theme';
+  const themeLabel = theme === 'light' ? t('common.theme.dark') : t('common.theme.light');
+  const themeAriaLabel = theme === 'light' ? t('common.theme.switchToDark') : t('common.theme.switchToLight');
   const ThemeIcon = theme === 'light' ? MoonIcon : SunIcon;
+  const portalTitle = t('monitoring.title');
+  const moreLabel = t('monitoring.more');
+  const navLabel = t('monitoring.services');
+  const refreshLabel = t('monitoring.refresh');
 
   return (
     <header className="portal-header">
       <div className="portal-headbar">
-        <span className="portal-title">Monitoring Portal</span>
+        <span className="portal-title">{portalTitle}</span>
         <div className="portal-spacer" />
+        <LanguageToggle />
         <button
           id="theme-toggle"
           type="button"
@@ -104,8 +113,8 @@ export function PortalHeader({ activeView, onSelectView, onRefresh, onToggleThem
           )}
           <span id="theme-label">{themeLabel}</span>
         </button>
-        <nav className="portal-links" aria-label="Monitoring services">
-          {PORTAL_LINKS.map((link) => (
+        <nav className="portal-links" aria-label={navLabel}>
+          {portalLinks.map((link) => (
             <Fragment key={link.id}>{renderLink(link)}</Fragment>
           ))}
         </nav>
@@ -117,10 +126,10 @@ export function PortalHeader({ activeView, onSelectView, onRefresh, onToggleThem
             aria-expanded={menuOpen}
             onClick={() => setMenuOpen((prev) => !prev)}
           >
-            More
+            {moreLabel}
           </button>
           <div className="portal-menu__dropdown" id="portal-menu" role="menu" aria-hidden={!menuOpen}>
-            {PORTAL_LINKS.map((link) => (
+            {portalLinks.map((link) => (
               <Fragment key={link.id}>{renderMenuItem(link, () => setMenuOpen(false))}</Fragment>
             ))}
           </div>
@@ -131,7 +140,7 @@ export function PortalHeader({ activeView, onSelectView, onRefresh, onToggleThem
           type="button"
           id="portal-refresh"
           className="portal-tabs__button portal-tabs__button--refresh"
-          aria-label="Refresh current view"
+          aria-label={refreshLabel}
           onClick={onRefresh}
         >
           ↻
@@ -145,7 +154,7 @@ export function PortalHeader({ activeView, onSelectView, onRefresh, onToggleThem
             aria-selected={activeView === view}
             onClick={() => onSelectView(view)}
           >
-            {formatPortalViewLabel(view)}
+            {formatPortalViewLabel(view, t)}
           </button>
         ))}
       </div>

--- a/web/app/(portal)/monitoring/components/PortalHeader.tsx
+++ b/web/app/(portal)/monitoring/components/PortalHeader.tsx
@@ -10,17 +10,13 @@ import {
   type PortalLink,
   type PortalView
 } from '../constants';
-import { MoonIcon, SunIcon } from '../../../_components/ThemeIcons';
-import { LanguageToggle } from '../../../_components/LanguageToggle';
 import { useLanguage } from '../../../_i18n/LanguageProvider';
+import { usePortalConfig } from '../../../_settings/PortalConfigProvider';
 
 type PortalHeaderProps = {
   activeView: PortalView;
   onSelectView: (view: PortalView) => void;
   onRefresh: () => void;
-  onToggleTheme: () => void;
-  theme: 'light' | 'dark';
-  themeReady: boolean;
 };
 
 function renderLink(link: PortalLink, onNavigate?: () => void) {
@@ -60,11 +56,12 @@ function renderMenuItem(link: PortalLink, onNavigate?: () => void) {
   );
 }
 
-export function PortalHeader({ activeView, onSelectView, onRefresh, onToggleTheme, theme, themeReady }: PortalHeaderProps) {
+export function PortalHeader({ activeView, onSelectView, onRefresh }: PortalHeaderProps) {
   const { t } = useLanguage();
+  const { routes } = usePortalConfig();
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
-  const portalLinks = useMemo(() => getPortalLinks(t), [t]);
+  const portalLinks = useMemo(() => getPortalLinks(t, routes), [routes, t]);
 
   useEffect(() => {
     if (!menuOpen) {
@@ -85,34 +82,20 @@ export function PortalHeader({ activeView, onSelectView, onRefresh, onToggleThem
     return () => document.removeEventListener('click', handleClick);
   }, [menuOpen]);
 
-  const themeLabel = theme === 'light' ? t('common.theme.dark') : t('common.theme.light');
-  const themeAriaLabel = theme === 'light' ? t('common.theme.switchToDark') : t('common.theme.switchToLight');
-  const ThemeIcon = theme === 'light' ? MoonIcon : SunIcon;
   const portalTitle = t('monitoring.title');
   const moreLabel = t('monitoring.more');
   const navLabel = t('monitoring.services');
   const refreshLabel = t('monitoring.refresh');
+  const settingsLabel = t('settings.linkLabel');
 
   return (
     <header className="portal-header">
       <div className="portal-headbar">
         <span className="portal-title">{portalTitle}</span>
         <div className="portal-spacer" />
-        <LanguageToggle />
-        <button
-          id="theme-toggle"
-          type="button"
-          className="theme-toggle"
-          onClick={onToggleTheme}
-          aria-label={themeAriaLabel}
-        >
-          {themeReady ? (
-            <ThemeIcon className="theme-toggle__icon" focusable="false" />
-          ) : (
-            <SunIcon className="theme-toggle__icon" focusable="false" />
-          )}
-          <span id="theme-label">{themeLabel}</span>
-        </button>
+        <Link className="btn ghost settings-link" href="/settings">
+          {settingsLabel}
+        </Link>
         <nav className="portal-links" aria-label={navLabel}>
           {portalLinks.map((link) => (
             <Fragment key={link.id}>{renderLink(link)}</Fragment>

--- a/web/app/(portal)/monitoring/constants.ts
+++ b/web/app/(portal)/monitoring/constants.ts
@@ -1,12 +1,29 @@
+import type { TranslateFn } from '../../_i18n/LanguageProvider';
+
 export type PortalView = 'grafana' | 'prom' | 'kuma' | 'netdata';
 
 export const PORTAL_VIEWS: PortalView[] = ['grafana', 'prom', 'kuma', 'netdata'];
 
-export const PORTAL_ROUTES: Record<PortalView, string> = {
+const DEFAULT_PORTAL_ROUTES: Record<PortalView, string> = {
   grafana: 'https://mon-core.tail85b0de.ts.net:445/',
   prom: 'https://mon-core.tail85b0de.ts.net/prometheus/targets',
   kuma: 'https://mon-core.tail85b0de.ts.net:444/status/portal',
   netdata: 'https://mon-core.tail85b0de.ts.net/netdata/'
+};
+
+function env(key: string, fallback: string): string {
+  const value = process.env[key];
+  if (typeof value === 'string' && value.trim() !== '') {
+    return value;
+  }
+  return fallback;
+}
+
+export const PORTAL_ROUTES: Record<PortalView, string> = {
+  grafana: env('NEXT_PUBLIC_GRAFANA_URL', DEFAULT_PORTAL_ROUTES.grafana),
+  prom: env('NEXT_PUBLIC_PROM_URL', DEFAULT_PORTAL_ROUTES.prom),
+  kuma: env('NEXT_PUBLIC_KUMA_URL', DEFAULT_PORTAL_ROUTES.kuma),
+  netdata: env('NEXT_PUBLIC_NETDATA_URL', DEFAULT_PORTAL_ROUTES.netdata)
 };
 
 export type PortalLink = {
@@ -17,24 +34,33 @@ export type PortalLink = {
   accent?: boolean;
 };
 
-export const PORTAL_LINKS: PortalLink[] = [
-  { id: 'grafana', label: 'Open Grafana', href: PORTAL_ROUTES.grafana, external: true },
-  { id: 'prom', label: 'Prometheus Targets', href: PORTAL_ROUTES.prom, external: true },
-  { id: 'kuma', label: 'Uptime Kuma', href: PORTAL_ROUTES.kuma, external: true },
-  { id: 'netdata', label: 'Netdata', href: PORTAL_ROUTES.netdata, external: true },
-  { id: 'wol', label: 'WOL Control', href: '/wol', accent: true }
+type PortalLinkDefinition = Omit<PortalLink, 'label'> & { labelKey: string };
+
+const PORTAL_LINK_DEFINITIONS: PortalLinkDefinition[] = [
+  { id: 'grafana', labelKey: 'monitoring.links.grafana', href: PORTAL_ROUTES.grafana, external: true },
+  { id: 'prom', labelKey: 'monitoring.links.prom', href: PORTAL_ROUTES.prom, external: true },
+  { id: 'kuma', labelKey: 'monitoring.links.kuma', href: PORTAL_ROUTES.kuma, external: true },
+  { id: 'netdata', labelKey: 'monitoring.links.netdata', href: PORTAL_ROUTES.netdata, external: true },
+  { id: 'wol', labelKey: 'monitoring.links.wol', href: '/wol', accent: true }
 ];
 
-export function formatPortalViewLabel(view: PortalView): string {
+export function getPortalLinks(t: TranslateFn): PortalLink[] {
+  return PORTAL_LINK_DEFINITIONS.map(({ labelKey, ...link }) => ({
+    ...link,
+    label: t(labelKey)
+  }));
+}
+
+export function formatPortalViewLabel(view: PortalView, t: TranslateFn): string {
   switch (view) {
     case 'grafana':
-      return 'Grafana';
+      return t('monitoring.views.grafana');
     case 'prom':
-      return 'Prometheus';
+      return t('monitoring.views.prom');
     case 'kuma':
-      return 'Uptime Kuma';
+      return t('monitoring.views.kuma');
     case 'netdata':
-      return 'Netdata';
+      return t('monitoring.views.netdata');
     default:
       return view;
   }

--- a/web/app/(portal)/monitoring/hooks/usePortalView.ts
+++ b/web/app/(portal)/monitoring/hooks/usePortalView.ts
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { PORTAL_ROUTES, PORTAL_VIEWS, type PortalView } from '../constants';
+import { PORTAL_VIEWS, type PortalView } from '../constants';
+import { usePortalConfig } from '../../../_settings/PortalConfigProvider';
 
 function resolveInitialView(): PortalView {
   if (typeof window === 'undefined') {
@@ -16,6 +17,7 @@ function resolveInitialView(): PortalView {
 }
 
 export function usePortalView() {
+  const { routes } = usePortalConfig();
   const [view, setView] = useState<PortalView>(() => resolveInitialView());
   const [refreshToken, setRefreshToken] = useState(0);
 
@@ -38,7 +40,7 @@ export function usePortalView() {
     window.history.replaceState(null, '', `#${view}`);
   }, [view]);
 
-  const baseSrc = PORTAL_ROUTES[view] ?? PORTAL_ROUTES.grafana;
+  const baseSrc = routes[view] ?? routes.grafana;
 
   const iframeSrc = useMemo(() => {
     if (!refreshToken) {

--- a/web/app/(portal)/monitoring/page.tsx
+++ b/web/app/(portal)/monitoring/page.tsx
@@ -12,7 +12,7 @@ export default function MonitoringPage() {
   useBodyClass('portal-body');
   useViewportHeight('--portal-vh');
 
-  const { theme, toggleTheme, ready } = useTheme();
+  useTheme();
   const { view, selectView, iframeSrc, refresh } = usePortalView();
 
   return (
@@ -21,9 +21,6 @@ export default function MonitoringPage() {
         activeView={view}
         onSelectView={selectView}
         onRefresh={refresh}
-        onToggleTheme={toggleTheme}
-        theme={theme}
-        themeReady={ready}
       />
       <PortalFrame src={iframeSrc} />
     </>

--- a/web/app/_components/LanguageToggle.tsx
+++ b/web/app/_components/LanguageToggle.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { useLanguage } from '../_i18n/LanguageProvider';
+
+type LanguageToggleProps = {
+  className?: string;
+};
+
+export function LanguageToggle({ className }: LanguageToggleProps) {
+  const { language, toggleLanguage, t } = useLanguage();
+
+  const { code, label } = useMemo(() => {
+    if (language === 'ko') {
+      return {
+        code: t('common.language.shortKorean'),
+        label: t('common.language.switchToEnglish')
+      };
+    }
+    return {
+      code: t('common.language.shortEnglish'),
+      label: t('common.language.switchToKorean')
+    };
+  }, [language, t]);
+
+  return (
+    <button
+      type="button"
+      className={`language-toggle${className ? ` ${className}` : ''}`}
+      data-language={language}
+      onClick={toggleLanguage}
+      aria-label={label}
+      title={label}
+    >
+      <span className="language-toggle__code">{code}</span>
+    </button>
+  );
+}

--- a/web/app/_i18n/LanguageProvider.tsx
+++ b/web/app/_i18n/LanguageProvider.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+import en from './translations/en.json';
+import ko from './translations/ko.json';
+
+export type Language = 'en' | 'ko';
+
+export type TranslateParams = Record<string, string | number>;
+
+export type TranslateFn = (key: string, params?: TranslateParams) => string;
+
+type LanguageContextValue = {
+  language: Language;
+  setLanguage: (language: Language) => void;
+  toggleLanguage: () => void;
+  t: TranslateFn;
+};
+
+type TranslationRecord = Record<string, unknown>;
+
+type TranslationMap = Record<Language, TranslationRecord>;
+
+const TRANSLATIONS: TranslationMap = {
+  en: en as TranslationRecord,
+  ko: ko as TranslationRecord
+};
+
+const STORAGE_KEY = 'portal-language';
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+function interpolate(template: string, params?: TranslateParams): string {
+  if (!params) {
+    return template;
+  }
+  return template.replace(/\{([^}]+)\}/g, (match, token) => {
+    const key = token.trim();
+    if (!key) {
+      return match;
+    }
+    const value = params[key];
+    return value === undefined ? match : String(value);
+  });
+}
+
+function resolveKey(map: TranslationRecord, key: string): unknown {
+  return key.split('.').reduce<unknown>((acc, segment) => {
+    if (acc && typeof acc === 'object' && segment in (acc as Record<string, unknown>)) {
+      return (acc as Record<string, unknown>)[segment];
+    }
+    return undefined;
+  }, map);
+}
+
+function createTranslator(language: Language): TranslateFn {
+  return (key, params) => {
+    const primary = resolveKey(TRANSLATIONS[language], key);
+    const fallback = language === 'en' ? undefined : resolveKey(TRANSLATIONS.en, key);
+    const value = primary ?? fallback;
+    if (typeof value === 'string') {
+      return interpolate(value, params);
+    }
+    if (typeof value === 'number') {
+      return String(value);
+    }
+    return key;
+  };
+}
+
+function getInitialLanguage(): Language {
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === 'en' || stored === 'ko') {
+      return stored;
+    }
+    const browser = window.navigator.language || window.navigator.languages?.[0];
+    if (browser?.toLowerCase().startsWith('en')) {
+      return 'en';
+    }
+    if (browser?.toLowerCase().startsWith('ko')) {
+      return 'ko';
+    }
+  }
+  return 'ko';
+}
+
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  const [language, setLanguageState] = useState<Language>(() => getInitialLanguage());
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const initial = getInitialLanguage();
+    setLanguageState(initial);
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) {
+      return;
+    }
+    if (typeof document !== 'undefined') {
+      document.documentElement.lang = language;
+    }
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, language);
+    }
+  }, [hydrated, language]);
+
+  const setLanguage = useCallback((next: Language) => {
+    setLanguageState(next);
+  }, []);
+
+  const toggleLanguage = useCallback(() => {
+    setLanguageState((prev) => (prev === 'ko' ? 'en' : 'ko'));
+  }, []);
+
+  const translator = useMemo(() => createTranslator(language), [language]);
+
+  const value = useMemo<LanguageContextValue>(
+    () => ({
+      language,
+      setLanguage,
+      toggleLanguage,
+      t: translator
+    }),
+    [language, setLanguage, toggleLanguage, translator]
+  );
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+}
+
+export function useLanguage(): LanguageContextValue {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error('useLanguage must be used within a LanguageProvider');
+  }
+  return context;
+}

--- a/web/app/_i18n/translations/en.json
+++ b/web/app/_i18n/translations/en.json
@@ -1,0 +1,167 @@
+{
+  "common": {
+    "theme": {
+      "light": "Light",
+      "dark": "Dark",
+      "switchToLight": "Switch to light theme",
+      "switchToDark": "Switch to dark theme"
+    },
+    "language": {
+      "switchToEnglish": "Switch to English",
+      "switchToKorean": "Switch to Korean",
+      "shortEnglish": "EN",
+      "shortKorean": "KO"
+    },
+    "buttons": {
+      "close": "Close",
+      "cancel": "Cancel",
+      "delete": "Delete",
+      "save": "Save",
+      "clear": "Clear"
+    }
+  },
+  "monitoring": {
+    "title": "Monitoring Portal",
+    "more": "More",
+    "services": "Monitoring services",
+    "refresh": "Refresh current view",
+    "frameTitle": "Monitoring iframe",
+    "dialogTitle": "Monitoring Portal",
+    "dialogClose": "Close",
+    "dialogFrameTitle": "Monitoring portal",
+    "banner": {
+      "description": "Open the monitoring portal anytime for dashboards and telemetry.",
+      "open": "Open Portal"
+    },
+    "links": {
+      "grafana": "Open Grafana",
+      "prom": "Prometheus Targets",
+      "kuma": "Uptime Kuma",
+      "netdata": "Netdata",
+      "wol": "WOL Control"
+    },
+    "views": {
+      "grafana": "Grafana",
+      "prom": "Prometheus",
+      "kuma": "Uptime Kuma",
+      "netdata": "Netdata"
+    }
+  },
+  "wol": {
+    "header": {
+      "title": "WOL-Web",
+      "subtitle": "Control Wake-on-LAN and power actions for your Tailnet devices.",
+      "searchPlaceholder": "Search name or IP",
+      "refresh": "Refresh Status",
+      "portal": "Monitoring Window",
+      "addTarget": "+ Add Target"
+    },
+    "banner": {
+      "title": "Monitoring Portal",
+      "description": "Open the monitoring portal anytime for dashboards and telemetry.",
+      "open": "Open Portal"
+    },
+    "targets": {
+      "title": "Targets",
+      "subtitle": "Wake, shut down, or reboot devices registered in your Tailnet.",
+      "summary": "Total {total} / Showing {showing}",
+      "columns": {
+        "name": "Name",
+        "ip": "IP",
+        "mac": "MAC",
+        "status": "Status",
+        "recent": "Recent",
+        "actions": "Actions"
+      },
+      "status": {
+        "online": "Online",
+        "offline": "Offline",
+        "unknown": "Unknown"
+      },
+      "macNotSet": "Not set",
+      "macMissingBadge": "MAC not set",
+      "wakeDisabled": "MAC not set - Wake disabled",
+      "wakeTitle": "Wake on LAN",
+      "empty": "No targets yet. Use the “+ Add Target” button to get started.",
+      "actions": {
+        "wake": "Wake",
+        "shutdown": "Shutdown",
+        "reboot": "Reboot",
+        "edit": "Edit",
+        "delete": "Delete"
+      }
+    },
+    "logs": {
+      "title": "Action History",
+      "subtitle": "Only commands you trigger from this page are listed.",
+      "clear": "Clear",
+      "empty": "No actions yet. Use the controls above to send a command.",
+      "status": {
+        "pending": "In Progress",
+        "success": "Success",
+        "error": "Failed"
+      },
+      "targetLabel": "Target"
+    },
+    "targetModal": {
+      "title": {
+        "create": "Add Target",
+        "edit": "Edit Target"
+      },
+      "fields": {
+        "name": "Name",
+        "nameHint": "Use lowercase letters, numbers, and hyphen only (e.g., mainpc).",
+        "ip": "IP address",
+        "ipPlaceholder": "192.168.0.10",
+        "advancedSummary": "Advanced (MAC address)",
+        "mac": "MAC address (optional)",
+        "macPlaceholder": "AA:BB:CC:DD:EE:FF",
+        "macHint": "If omitted, MAC is learned automatically when the device is online."
+      },
+      "actions": {
+        "save": "Save",
+        "cancel": "Cancel"
+      }
+    },
+    "confirmDelete": {
+      "title": "Confirm Delete",
+      "message": "Delete target {name}?",
+      "delete": "Delete",
+      "cancel": "Cancel"
+    },
+    "portalDialog": {
+      "title": "Monitoring Portal",
+      "close": "Close",
+      "iframeTitle": "Monitoring portal"
+    },
+    "toasts": {
+      "targetsLoaded": "Targets loaded.",
+      "targetsLoadFailed": "Failed to load targets.",
+      "statusesRefreshed": "Statuses refreshed.",
+      "missingFields": "Please enter both name and IP.",
+      "targetUpdated": "Updated target.",
+      "targetAdded": "Added target.",
+      "saveFailed": "Failed to save.",
+      "targetDeleted": "Deleted target.",
+      "deleteFailed": "Failed to delete target.",
+      "macRequired": "Cannot wake without a MAC address."
+    },
+    "actions": {
+      "labels": {
+        "wake": "Wake",
+        "shutdown": "Shutdown",
+        "reboot": "Reboot"
+      },
+      "progress": "Sending {action} command to {target}…",
+      "success": "Sent {action} command to {target}.",
+      "failure": "Failed to send {action} command."
+    }
+  },
+  "format": {
+    "relative": {
+      "justNow": "just now",
+      "minutesAgo": "{count} min ago",
+      "hoursAgo": "{count} hr ago"
+    }
+  }
+}

--- a/web/app/_i18n/translations/en.json
+++ b/web/app/_i18n/translations/en.json
@@ -161,6 +161,11 @@
     "title": "Portal Settings",
     "subtitle": "Adjust how the portal looks, choose your language, customize monitoring links, and manage rarely changed Wake-on-LAN options.",
     "linkLabel": "Settings",
+    "actions": {
+      "exit": "Exit settings",
+      "save": "Save changes",
+      "saving": "Saving…"
+    },
     "appearance": {
       "title": "Appearance",
       "description": "Choose a theme for the entire portal.",
@@ -178,6 +183,9 @@
       "description": "Override monitoring endpoints without changing deployment environment variables.",
       "reset": "Reset to defaults",
       "statusLabel": "Environment key",
+      "hint": "Update the URLs and save to override the defaults.",
+      "saving": "Saving monitoring links…",
+      "saved": "Monitoring links saved.",
       "labels": {
         "grafana": "Grafana URL",
         "prom": "Prometheus URL",

--- a/web/app/_i18n/translations/en.json
+++ b/web/app/_i18n/translations/en.json
@@ -157,6 +157,45 @@
       "failure": "Failed to send {action} command."
     }
   },
+  "settings": {
+    "title": "Portal Settings",
+    "subtitle": "Adjust how the portal looks, choose your language, customize monitoring links, and manage rarely changed Wake-on-LAN options.",
+    "linkLabel": "Settings",
+    "appearance": {
+      "title": "Appearance",
+      "description": "Choose a theme for the entire portal.",
+      "light": "Light theme",
+      "dark": "Dark theme"
+    },
+    "language": {
+      "title": "Language",
+      "description": "Pick the default language for the interface.",
+      "korean": "한국어",
+      "english": "English"
+    },
+    "monitoring": {
+      "title": "Monitoring links",
+      "description": "Override monitoring endpoints without changing deployment environment variables.",
+      "reset": "Reset to defaults",
+      "statusLabel": "Environment key",
+      "labels": {
+        "grafana": "Grafana URL",
+        "prom": "Prometheus URL",
+        "kuma": "Uptime Kuma URL",
+        "netdata": "Netdata URL"
+      }
+    },
+    "targets": {
+      "title": "Quick target setup",
+      "description": "Add a Wake-on-LAN target from the settings panel without leaving the page.",
+      "submit": "Save target",
+      "saving": "Saving…",
+      "success": "Target saved.",
+      "error": "Please fill in the required fields.",
+      "hint": "Name and IP address are required. MAC can be added now or detected later.",
+      "manageLink": "Open WOL management"
+    }
+  },
   "format": {
     "relative": {
       "justNow": "just now",

--- a/web/app/_i18n/translations/ko.json
+++ b/web/app/_i18n/translations/ko.json
@@ -161,6 +161,11 @@
     "title": "포털 설정",
     "subtitle": "포털의 화면 모드와 언어, 모니터링 링크, 자주 변경하지 않는 WOL 설정을 한 곳에서 관리하세요.",
     "linkLabel": "설정",
+    "actions": {
+      "exit": "설정 나가기",
+      "save": "변경 사항 저장",
+      "saving": "저장 중…"
+    },
     "appearance": {
       "title": "화면 모드",
       "description": "포털 전체에 적용할 테마를 선택하세요.",
@@ -178,6 +183,9 @@
       "description": "배포 환경 변수를 바꾸지 않고 모니터링 엔드포인트를 덮어쓸 수 있습니다.",
       "reset": "기본값으로 초기화",
       "statusLabel": "환경 변수 키",
+      "hint": "URL을 수정한 뒤 저장하여 기본값을 덮어쓸 수 있습니다.",
+      "saving": "모니터링 링크를 저장하는 중…",
+      "saved": "모니터링 링크가 저장되었습니다.",
       "labels": {
         "grafana": "Grafana URL",
         "prom": "Prometheus URL",

--- a/web/app/_i18n/translations/ko.json
+++ b/web/app/_i18n/translations/ko.json
@@ -1,0 +1,167 @@
+{
+  "common": {
+    "theme": {
+      "light": "라이트",
+      "dark": "다크",
+      "switchToLight": "라이트 테마로 전환",
+      "switchToDark": "다크 테마로 전환"
+    },
+    "language": {
+      "switchToEnglish": "영어로 변경",
+      "switchToKorean": "한국어로 변경",
+      "shortEnglish": "EN",
+      "shortKorean": "KO"
+    },
+    "buttons": {
+      "close": "닫기",
+      "cancel": "취소",
+      "delete": "삭제",
+      "save": "저장",
+      "clear": "비우기"
+    }
+  },
+  "monitoring": {
+    "title": "모니터링 포털",
+    "more": "더 보기",
+    "services": "모니터링 서비스",
+    "refresh": "현재 화면 새로고침",
+    "frameTitle": "모니터링 화면",
+    "dialogTitle": "모니터링 포털",
+    "dialogClose": "닫기",
+    "dialogFrameTitle": "모니터링 포털",
+    "banner": {
+      "description": "모니터링 포털에서 대시보드와 텔레메트리를 언제든 확인하세요.",
+      "open": "포털 열기"
+    },
+    "links": {
+      "grafana": "Grafana 열기",
+      "prom": "Prometheus 대상",
+      "kuma": "Uptime Kuma",
+      "netdata": "Netdata",
+      "wol": "WOL 제어"
+    },
+    "views": {
+      "grafana": "Grafana",
+      "prom": "Prometheus",
+      "kuma": "Uptime Kuma",
+      "netdata": "Netdata"
+    }
+  },
+  "wol": {
+    "header": {
+      "title": "WOL-Web",
+      "subtitle": "Tailnet 장치의 Wake-on-LAN 및 전원 작업을 제어합니다.",
+      "searchPlaceholder": "이름 또는 IP 검색",
+      "refresh": "상태 새로고침",
+      "portal": "모니터링 창",
+      "addTarget": "+ 대상 추가"
+    },
+    "banner": {
+      "title": "모니터링 포털",
+      "description": "모니터링 포털에서 대시보드와 텔레메트리를 언제든 확인하세요.",
+      "open": "포털 열기"
+    },
+    "targets": {
+      "title": "대상",
+      "subtitle": "Tailnet에 등록된 장치를 깨우거나 종료 또는 재부팅합니다.",
+      "summary": "전체 {total}개 / 표시 {showing}개",
+      "columns": {
+        "name": "이름",
+        "ip": "IP",
+        "mac": "MAC",
+        "status": "상태",
+        "recent": "최근",
+        "actions": "작업"
+      },
+      "status": {
+        "online": "온라인",
+        "offline": "오프라인",
+        "unknown": "알 수 없음"
+      },
+      "macNotSet": "미설정",
+      "macMissingBadge": "MAC 미설정",
+      "wakeDisabled": "MAC 미설정 - Wake 비활성화",
+      "wakeTitle": "Wake on LAN",
+      "empty": "아직 대상이 없습니다. “+ 대상 추가” 버튼으로 시작하세요.",
+      "actions": {
+        "wake": "깨우기",
+        "shutdown": "종료",
+        "reboot": "재부팅",
+        "edit": "편집",
+        "delete": "삭제"
+      }
+    },
+    "logs": {
+      "title": "작업 기록",
+      "subtitle": "이 페이지에서 실행한 명령만 표시됩니다.",
+      "clear": "비우기",
+      "empty": "아직 기록이 없습니다. 위의 컨트롤로 명령을 보내보세요.",
+      "status": {
+        "pending": "진행 중",
+        "success": "성공",
+        "error": "실패"
+      },
+      "targetLabel": "대상"
+    },
+    "targetModal": {
+      "title": {
+        "create": "대상 추가",
+        "edit": "대상 수정"
+      },
+      "fields": {
+        "name": "이름",
+        "nameHint": "소문자, 숫자, 하이픈만 사용하세요 (예: mainpc).",
+        "ip": "IP 주소",
+        "ipPlaceholder": "192.168.0.10",
+        "advancedSummary": "고급 설정 (MAC 주소)",
+        "mac": "MAC 주소 (선택)",
+        "macPlaceholder": "AA:BB:CC:DD:EE:FF",
+        "macHint": "생략하면 장치가 온라인일 때 MAC을 자동으로 학습합니다."
+      },
+      "actions": {
+        "save": "저장",
+        "cancel": "취소"
+      }
+    },
+    "confirmDelete": {
+      "title": "삭제 확인",
+      "message": "대상 {name}을(를) 삭제할까요?",
+      "delete": "삭제",
+      "cancel": "취소"
+    },
+    "portalDialog": {
+      "title": "모니터링 포털",
+      "close": "닫기",
+      "iframeTitle": "모니터링 포털"
+    },
+    "toasts": {
+      "targetsLoaded": "대상을 불러왔습니다.",
+      "targetsLoadFailed": "대상을 불러오지 못했습니다.",
+      "statusesRefreshed": "상태를 새로고침했습니다.",
+      "missingFields": "이름과 IP를 모두 입력하세요.",
+      "targetUpdated": "대상을 수정했습니다.",
+      "targetAdded": "대상을 추가했습니다.",
+      "saveFailed": "저장하지 못했습니다.",
+      "targetDeleted": "대상을 삭제했습니다.",
+      "deleteFailed": "대상을 삭제하지 못했습니다.",
+      "macRequired": "MAC 주소가 없어 깨울 수 없습니다."
+    },
+    "actions": {
+      "labels": {
+        "wake": "깨우기",
+        "shutdown": "종료",
+        "reboot": "재부팅"
+      },
+      "progress": "{target}에 {action} 명령을 보내는 중…",
+      "success": "{target}에 {action} 명령을 보냈습니다.",
+      "failure": "{action} 명령을 보내지 못했습니다."
+    }
+  },
+  "format": {
+    "relative": {
+      "justNow": "방금 전",
+      "minutesAgo": "{count}분 전",
+      "hoursAgo": "{count}시간 전"
+    }
+  }
+}

--- a/web/app/_i18n/translations/ko.json
+++ b/web/app/_i18n/translations/ko.json
@@ -157,6 +157,45 @@
       "failure": "{action} 명령을 보내지 못했습니다."
     }
   },
+  "settings": {
+    "title": "포털 설정",
+    "subtitle": "포털의 화면 모드와 언어, 모니터링 링크, 자주 변경하지 않는 WOL 설정을 한 곳에서 관리하세요.",
+    "linkLabel": "설정",
+    "appearance": {
+      "title": "화면 모드",
+      "description": "포털 전체에 적용할 테마를 선택하세요.",
+      "light": "라이트 테마",
+      "dark": "다크 테마"
+    },
+    "language": {
+      "title": "언어",
+      "description": "기본으로 사용할 인터페이스 언어를 선택하세요.",
+      "korean": "한국어",
+      "english": "영어"
+    },
+    "monitoring": {
+      "title": "모니터링 링크",
+      "description": "배포 환경 변수를 바꾸지 않고 모니터링 엔드포인트를 덮어쓸 수 있습니다.",
+      "reset": "기본값으로 초기화",
+      "statusLabel": "환경 변수 키",
+      "labels": {
+        "grafana": "Grafana URL",
+        "prom": "Prometheus URL",
+        "kuma": "Uptime Kuma URL",
+        "netdata": "Netdata URL"
+      }
+    },
+    "targets": {
+      "title": "빠른 대상 추가",
+      "description": "설정 패널에서 바로 Wake-on-LAN 대상을 등록할 수 있습니다.",
+      "submit": "대상 저장",
+      "saving": "저장 중…",
+      "success": "대상을 저장했습니다.",
+      "error": "필수 항목을 입력하세요.",
+      "hint": "이름과 IP 주소는 필수입니다. MAC 주소는 지금 입력하거나 나중에 자동으로 채워질 수 있습니다.",
+      "manageLink": "WOL 관리 열기"
+    }
+  },
   "format": {
     "relative": {
       "justNow": "방금 전",

--- a/web/app/_settings/PortalConfigProvider.tsx
+++ b/web/app/_settings/PortalConfigProvider.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+import { PORTAL_VIEWS, resolvePortalRoutes, type PortalView } from '../(portal)/monitoring/constants';
+
+type PortalRouteOverrides = Partial<Record<PortalView, string>>;
+
+type PortalConfigContextValue = {
+  ready: boolean;
+  routes: Record<PortalView, string>;
+  overrides: PortalRouteOverrides;
+  setRoute: (view: PortalView, url: string) => void;
+  resetRoutes: () => void;
+};
+
+const STORAGE_KEY = 'portal-config';
+
+const PortalConfigContext = createContext<PortalConfigContextValue | undefined>(undefined);
+
+function normalizeUrl(value: string): string {
+  return value.trim();
+}
+
+export function PortalConfigProvider({ children }: { children: React.ReactNode }) {
+  const [overrides, setOverrides] = useState<PortalRouteOverrides>({});
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored) as PortalRouteOverrides | null;
+        if (parsed && typeof parsed === 'object') {
+          setOverrides(parsed);
+        }
+      }
+    } catch (error) {
+      console.warn('Failed to load portal config', error);
+    } finally {
+      setReady(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!ready || typeof window === 'undefined') {
+      return;
+    }
+    try {
+      const serialized = JSON.stringify(overrides);
+      window.localStorage.setItem(STORAGE_KEY, serialized);
+    } catch (error) {
+      console.warn('Failed to persist portal config', error);
+    }
+  }, [overrides, ready]);
+
+  const routes = useMemo(() => resolvePortalRoutes(overrides), [overrides]);
+
+  const value = useMemo<PortalConfigContextValue>(() => ({
+    ready,
+    routes,
+    overrides,
+    setRoute: (view: PortalView, url: string) => {
+      setOverrides((prev) => {
+        const next = normalizeUrl(url);
+        if (!next) {
+          const { [view]: _removed, ...rest } = prev;
+          return rest;
+        }
+        return { ...prev, [view]: next };
+      });
+    },
+    resetRoutes: () => {
+      setOverrides({});
+    }
+  }), [overrides, ready, routes]);
+
+  return <PortalConfigContext.Provider value={value}>{children}</PortalConfigContext.Provider>;
+}
+
+export function usePortalConfig(): PortalConfigContextValue {
+  const context = useContext(PortalConfigContext);
+  if (!context) {
+    throw new Error('usePortalConfig must be used within a PortalConfigProvider');
+  }
+  return context;
+}
+

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -973,6 +973,26 @@ summary:focus-visible {
   gap: 2.5rem;
 }
 
+.settings-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.settings-header__content {
+  flex: 1 1 20rem;
+  min-width: 16rem;
+}
+
+.settings-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .settings-header h1 {
   margin: 0;
   font-size: clamp(2rem, 4vw, 2.75rem);

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -645,9 +645,29 @@ body {
   color: inherit;
 }
 
+.language-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem;
+  min-width: 2.5rem;
+  border-radius: 999px;
+  border: 0.0625rem solid var(--color-border-strong);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
 .theme-toggle__icon {
   width: 1.25rem;
   height: 1.25rem;
+}
+
+.language-toggle__code {
+  display: inline-block;
 }
 
 .theme-toggle span {
@@ -656,6 +676,10 @@ body {
 }
 
 [data-theme='light'] .theme-toggle {
+  background: rgba(226, 232, 240, 0.85);
+}
+
+[data-theme='light'] .language-toggle {
   background: rgba(226, 232, 240, 0.85);
 }
 
@@ -804,6 +828,7 @@ details.field.advanced summary {
 .portal-dialog__close:focus-visible,
 .btn:focus-visible,
 .theme-toggle:focus-visible,
+.language-toggle:focus-visible,
 input:focus-visible,
 summary:focus-visible {
   outline: 0.125rem solid var(--color-accent-border);

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -959,6 +959,180 @@ summary:focus-visible {
   background: rgba(8, 11, 19, 0.65);
 }
 
+.settings-body {
+  min-height: 100vh;
+  background: var(--page-background);
+}
+
+.settings-page {
+  width: min(72rem, 100%);
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.settings-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+}
+
+.settings-header p {
+  margin: 0.75rem 0 0;
+  color: var(--color-muted);
+  font-size: 1rem;
+  max-width: 48rem;
+}
+
+.settings-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18.5rem, 1fr));
+  gap: 1.75rem;
+}
+
+.settings-card {
+  background: linear-gradient(170deg, var(--color-bg-surface), var(--color-bg-elevated));
+  border-radius: 1.5rem;
+  border: 0.0625rem solid var(--color-border);
+  box-shadow: var(--shadow-elevated);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  backdrop-filter: blur(1rem);
+}
+
+.settings-card--wide {
+  grid-column: 1 / -1;
+}
+
+.settings-card h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.settings-card__description {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9375rem;
+}
+
+.settings-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.settings-options {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.settings-option {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.65rem 1rem;
+  border-radius: 0.9rem;
+  border: 0.075rem solid var(--color-border);
+  background: rgba(10, 16, 30, 0.75);
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.settings-option input {
+  display: none;
+}
+
+.settings-option.selected {
+  border-color: var(--color-accent-border);
+  box-shadow: 0 0 0.75rem rgba(59, 130, 246, 0.3);
+  transform: translateY(-0.05rem);
+}
+
+.settings-fields {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.settings-field__label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.settings-field input {
+  padding: 0.75rem 0.875rem;
+  border-radius: 0.85rem;
+  border: 0.0625rem solid var(--color-border-strong);
+  background: rgba(8, 12, 24, 0.9);
+  color: inherit;
+}
+
+[data-theme='light'] .settings-field input {
+  background: rgba(226, 232, 240, 0.9);
+}
+
+.settings-field__hint {
+  color: var(--color-muted);
+  font-size: 0.75rem;
+}
+
+.settings-field__hint code {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 0.4rem;
+  padding: 0.1rem 0.35rem;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.72rem;
+}
+
+[data-theme='light'] .settings-field__hint code {
+  background: rgba(203, 213, 225, 0.6);
+}
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.settings-message {
+  min-height: 1.5rem;
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--color-muted);
+}
+
+.settings-message--success {
+  color: rgba(134, 239, 172, 0.95);
+}
+
+.settings-message--error {
+  color: rgba(254, 202, 202, 0.95);
+}
+
+.settings-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.settings-link {
+  font-weight: 600;
+}
+
 @keyframes spin {
   to {
     transform: rotate(360deg);
@@ -993,6 +1167,10 @@ summary:focus-visible {
 
   .portal-links {
     display: none;
+  }
+
+  .settings-grid {
+    grid-template-columns: repeat(auto-fit, minmax(100%, 1fr));
   }
 }
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import './globals.css';
+import { AppProviders } from './providers';
 
 export const metadata: Metadata = {
   title: 'WOL Web Portal',
@@ -16,7 +17,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko" suppressHydrationWarning>
-      <body>{children}</body>
+      <body>
+        <AppProviders>{children}</AppProviders>
+      </body>
     </html>
   );
 }

--- a/web/app/providers.tsx
+++ b/web/app/providers.tsx
@@ -3,7 +3,12 @@
 import type { PropsWithChildren } from 'react';
 
 import { LanguageProvider } from './_i18n/LanguageProvider';
+import { PortalConfigProvider } from './_settings/PortalConfigProvider';
 
 export function AppProviders({ children }: PropsWithChildren<{}>) {
-  return <LanguageProvider>{children}</LanguageProvider>;
+  return (
+    <LanguageProvider>
+      <PortalConfigProvider>{children}</PortalConfigProvider>
+    </LanguageProvider>
+  );
 }

--- a/web/app/providers.tsx
+++ b/web/app/providers.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import type { PropsWithChildren } from 'react';
+
+import { LanguageProvider } from './_i18n/LanguageProvider';
+
+export function AppProviders({ children }: PropsWithChildren<{}>) {
+  return <LanguageProvider>{children}</LanguageProvider>;
+}

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import Link from 'next/link';
+import { FormEvent, useMemo, useState } from 'react';
+
+import { useBodyClass } from '../_hooks/useBodyClass';
+import { useTheme } from '../_hooks/useTheme';
+import { useLanguage } from '../_i18n/LanguageProvider';
+import type { Language } from '../_i18n/LanguageProvider';
+import { usePortalConfig } from '../_settings/PortalConfigProvider';
+import {
+  DEFAULT_PORTAL_ROUTES,
+  PORTAL_ENV_KEYS,
+  PORTAL_VIEWS,
+  type PortalView
+} from '../(portal)/monitoring/constants';
+import { request } from '../(management)/wol/_lib/api';
+import type { RequestError, TargetFormState } from '../(management)/wol/_lib/types';
+
+type TargetStatus = 'idle' | 'saving' | 'success' | 'error';
+
+const INITIAL_TARGET_FORM: TargetFormState = { name: '', ip: '', mac: '' };
+
+export default function SettingsPage() {
+  useBodyClass('settings-body');
+
+  const { language, setLanguage, t } = useLanguage();
+  const { theme, setTheme } = useTheme();
+  const { routes, overrides, setRoute, resetRoutes } = usePortalConfig();
+
+  const [targetForm, setTargetForm] = useState<TargetFormState>(INITIAL_TARGET_FORM);
+  const [targetStatus, setTargetStatus] = useState<TargetStatus>('idle');
+  const [targetMessage, setTargetMessage] = useState('');
+
+  const updateTargetForm = (patch: Partial<TargetFormState>) => {
+    setTargetStatus('idle');
+    setTargetMessage('');
+    setTargetForm((prev) => ({ ...prev, ...patch }));
+  };
+
+  const appearanceTitle = t('settings.appearance.title');
+  const appearanceDescription = t('settings.appearance.description');
+  const themeOptions = useMemo(
+    () => [
+      { value: 'light' as const, label: t('settings.appearance.light') },
+      { value: 'dark' as const, label: t('settings.appearance.dark') }
+    ],
+    [t]
+  );
+
+  const languageTitle = t('settings.language.title');
+  const languageDescription = t('settings.language.description');
+  const languageOptions = useMemo(
+    () => [
+      { value: 'ko' as Language, label: t('settings.language.korean') },
+      { value: 'en' as Language, label: t('settings.language.english') }
+    ],
+    [t]
+  );
+
+  const monitoringTitle = t('settings.monitoring.title');
+  const monitoringDescription = t('settings.monitoring.description');
+  const monitoringResetLabel = t('settings.monitoring.reset');
+  const monitoringStatusLabel = t('settings.monitoring.statusLabel');
+
+  const targetTitle = t('settings.targets.title');
+  const targetDescription = t('settings.targets.description');
+  const targetSubmitLabel = t('settings.targets.submit');
+  const targetSuccess = t('settings.targets.success');
+  const targetError = t('settings.targets.error');
+  const targetHint = t('settings.targets.hint');
+
+  const handleLanguageChange = (value: Language) => {
+    setLanguage(value);
+  };
+
+  const handleThemeChange = (value: 'light' | 'dark') => {
+    setTheme(value);
+  };
+
+  const handleRouteChange = (view: PortalView, value: string) => {
+    setRoute(view, value);
+  };
+
+  const handleTargetSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const name = targetForm.name.trim();
+    const ip = targetForm.ip.trim();
+    const mac = targetForm.mac.trim();
+    if (!name || !ip) {
+      setTargetMessage(targetError);
+      setTargetStatus('error');
+      return;
+    }
+
+    setTargetStatus('saving');
+    setTargetMessage('');
+    try {
+      const payload: Record<string, string> = { name, ip };
+      if (mac) {
+        payload.mac = mac;
+      }
+
+      await request('api/targets', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      });
+      setTargetStatus('success');
+      setTargetMessage(targetSuccess);
+      setTargetForm(INITIAL_TARGET_FORM);
+    } catch (error) {
+      console.error(error);
+      const detail = (error as RequestError)?.payload as { detail?: unknown; message?: unknown } | string | undefined;
+      const message =
+        typeof detail === 'string'
+          ? detail
+          : typeof detail?.detail === 'string'
+            ? detail.detail
+            : typeof detail?.message === 'string'
+              ? detail.message
+              : targetError;
+      setTargetStatus('error');
+      setTargetMessage(message);
+    }
+  };
+
+  return (
+    <main className="settings-page">
+      <header className="settings-header">
+        <h1>{t('settings.title')}</h1>
+        <p>{t('settings.subtitle')}</p>
+      </header>
+      <section className="settings-grid">
+        <article className="settings-card">
+          <h2>{appearanceTitle}</h2>
+          <p className="settings-card__description">{appearanceDescription}</p>
+          <div className="settings-options">
+            {themeOptions.map((option) => (
+              <label key={option.value} className={`settings-option${theme === option.value ? ' selected' : ''}`}>
+                <input
+                  type="radio"
+                  name="theme"
+                  value={option.value}
+                  checked={theme === option.value}
+                  onChange={() => handleThemeChange(option.value)}
+                />
+                <span>{option.label}</span>
+              </label>
+            ))}
+          </div>
+        </article>
+
+        <article className="settings-card">
+          <h2>{languageTitle}</h2>
+          <p className="settings-card__description">{languageDescription}</p>
+          <div className="settings-options">
+            {languageOptions.map((option) => (
+              <label key={option.value} className={`settings-option${language === option.value ? ' selected' : ''}`}>
+                <input
+                  type="radio"
+                  name="language"
+                  value={option.value}
+                  checked={language === option.value}
+                  onChange={() => handleLanguageChange(option.value)}
+                />
+                <span>{option.label}</span>
+              </label>
+            ))}
+          </div>
+        </article>
+
+        <article className="settings-card settings-card--wide">
+          <div className="settings-card__header">
+            <div>
+              <h2>{monitoringTitle}</h2>
+              <p className="settings-card__description">{monitoringDescription}</p>
+            </div>
+            <button type="button" className="btn ghost" onClick={resetRoutes}>
+              {monitoringResetLabel}
+            </button>
+          </div>
+          <div className="settings-fields">
+            {PORTAL_VIEWS.map((view) => {
+              const label = t(`settings.monitoring.labels.${view}`);
+              const envKey = PORTAL_ENV_KEYS[view];
+              const defaultValue = DEFAULT_PORTAL_ROUTES[view];
+              const overrideValue = overrides[view] ?? '';
+              return (
+                <label key={view} className="settings-field">
+                  <span className="settings-field__label">{label}</span>
+                  <input
+                    type="url"
+                    value={overrideValue || routes[view]}
+                    placeholder={defaultValue}
+                    onChange={(event) => handleRouteChange(view, event.target.value)}
+                  />
+                  <small className="settings-field__hint">
+                    {monitoringStatusLabel} <code>{envKey}</code>
+                  </small>
+                </label>
+              );
+            })}
+          </div>
+        </article>
+
+        <article className="settings-card settings-card--wide">
+          <h2>{targetTitle}</h2>
+          <p className="settings-card__description">{targetDescription}</p>
+          <form className="settings-form" onSubmit={handleTargetSubmit}>
+            <div className="settings-fields">
+              <label className="settings-field">
+                <span className="settings-field__label">{t('wol.targetModal.fields.name')}</span>
+                <input
+                  value={targetForm.name}
+                  onChange={(event) => updateTargetForm({ name: event.target.value })}
+                  required
+                  minLength={2}
+                  maxLength={32}
+                  pattern="[a-z0-9-]+"
+                />
+                <small className="settings-field__hint">{t('wol.targetModal.fields.nameHint')}</small>
+              </label>
+              <label className="settings-field">
+                <span className="settings-field__label">{t('wol.targetModal.fields.ip')}</span>
+                <input
+                  value={targetForm.ip}
+                  onChange={(event) => updateTargetForm({ ip: event.target.value })}
+                  required
+                  placeholder={t('wol.targetModal.fields.ipPlaceholder')}
+                />
+              </label>
+              <label className="settings-field">
+                <span className="settings-field__label">{t('wol.targetModal.fields.mac')}</span>
+                <input
+                  value={targetForm.mac}
+                  onChange={(event) => updateTargetForm({ mac: event.target.value })}
+                  placeholder={t('wol.targetModal.fields.macPlaceholder')}
+                />
+                <small className="settings-field__hint">{t('wol.targetModal.fields.macHint')}</small>
+              </label>
+            </div>
+            <p className={`settings-message settings-message--${targetStatus}`} role="status">
+              {targetMessage || targetHint}
+            </p>
+            <div className="settings-actions">
+              <button type="submit" className="btn primary" disabled={targetStatus === 'saving'}>
+                {targetStatus === 'saving' ? t('settings.targets.saving') : targetSubmitLabel}
+              </button>
+              <Link href="/wol" className="btn ghost">
+                {t('settings.targets.manageLink')}
+              </Link>
+            </div>
+          </form>
+        </article>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client-side language provider with English and Korean JSON resources and wrap the app in the new provider
- add a reusable language toggle control and update monitoring as well as WOL management UIs to load copy from translations
- extend shared styles and helpers so status text, dialogs, notifications, and relative time formatting reflect the active locale

## Testing
- npm run lint *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68de8433ead48328af2d97c1672dcb32